### PR TITLE
Fixes OVM3 module isolated build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,6 @@
     <groupId>cloud.cosmic</groupId>
     <artifactId>cosmic-plugins</artifactId>
     <version>5.0.0-SNAPSHOT</version>
-    <relativePath>../cosmic-core/plugins/pom.xml</relativePath>
   </parent>
   <dependencies>
     <dependency>


### PR DESCRIPTION
The build has been fixed by removing the relative path to the parent model. Now this plugin can be built in isolation, as long as the parent artefacts are present in the m2 local repo.
