### PR TITLE
Make cosmic the parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,10 +5,37 @@
   <name>Cosmic Plugin - Hypervisor OracleVM3</name>
   <parent>
     <groupId>cloud.cosmic</groupId>
-    <artifactId>cosmic-plugins</artifactId>
+    <artifactId>cosmic</artifactId>
     <version>5.0.0-SNAPSHOT</version>
   </parent>
   <dependencies>
+    <dependency>
+      <groupId>cloud.cosmic</groupId>
+      <artifactId>cloud-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>cloud.cosmic</groupId>
+      <artifactId>cloud-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>cloud.cosmic</groupId>
+      <artifactId>cloud-utils</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>cloud.cosmic</groupId>
+      <artifactId>cloud-framework-config</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>cloud.cosmic</groupId>
+      <artifactId>cloud-api</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>xml-apis</groupId>
       <artifactId>xml-apis</artifactId>
@@ -27,7 +54,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>${cs.commons-lang3.version}</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>


### PR DESCRIPTION
The parent pom of this module should be cosmic. In order for that to work, I've copied the dependencies defined in the previous parent pom (cosmic-plugins) into this one. These dependencies should be reviewed to assess if all of them are needed.
