### PR TITLE
Replace cloudstack-common with cosmic-common

### DIFF
--- a/src/main/java/com/cloud/hypervisor/ovm3/resources/helpers/Ovm3HypervisorSupport.java
+++ b/src/main/java/com/cloud/hypervisor/ovm3/resources/helpers/Ovm3HypervisorSupport.java
@@ -142,7 +142,7 @@ public class Ovm3HypervisorSupport {
       keyFile = new File(key);
     }
     if (keyFile == null || !keyFile.exists()) {
-      final String key = "/usr/share/cloudstack-common/scripts/vm/systemvm/"
+      final String key = "/usr/share/cosmic-common/scripts/vm/systemvm/"
           + filename;
       logger.warn("generated key retrieval failed " + key);
       keyFile = new File(key);


### PR DESCRIPTION
The cloudstack-common directory doesn't exist anymore and is replaced by cosmic-common.
