### PR TITLE
Define module version to enable automatic releasing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,6 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cloud-plugin-hypervisor-ovm3</artifactId>
   <name>Cosmic Plugin - Hypervisor OracleVM3</name>
+  <version>5.0.0.1-SNAPSHOT</version>
   <parent>
     <groupId>cloud.cosmic</groupId>
     <artifactId>cosmic</artifactId>


### PR DESCRIPTION
In order to automate releases we need to bump the parent version independently form the version of the modules. Therefore, the modules cannot inherit the version of the parent.

This PR defines the version of the module.
