### PR TITLE
Revert "Add dependency managment."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,26 +22,6 @@
     </snapshotRepository>
   </distributionManagement>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>xml-apis</groupId>
-        <artifactId>xml-apis</artifactId>
-        <version>1.4.01</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.xmlrpc</groupId>
-        <artifactId>xmlrpc-client</artifactId>
-        <version>3.1.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.xmlrpc</groupId>
-        <artifactId>xmlrpc-common</artifactId>
-        <version>3.1.3</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>cloud.cosmic</groupId>


### PR DESCRIPTION
This reverts commit 4200f69df7def59ea0120582b867583e6343c8e6.

Dependencies are now being managed by the parent pom.
